### PR TITLE
【修复BUG】测试url功能的转换url方法截取错误

### DIFF
--- a/xxl-api-admin/src/main/java/com/xxl/api/admin/controller/XxlApiTestController.java
+++ b/xxl-api-admin/src/main/java/com/xxl/api/admin/controller/XxlApiTestController.java
@@ -213,7 +213,7 @@ public class XxlApiTestController {
 				finalUrl += entry.getKey() + "=" + entry.getValue() + "&";
 			}
 		}
-		finalUrl = finalUrl.substring(0, finalUrl.length()-2);
+		finalUrl = finalUrl.substring(0, finalUrl.length()-1);
 		return finalUrl;
 	}
 


### PR DESCRIPTION
该方法是想把最后的'&'去掉，但是截取方法substring()写错了